### PR TITLE
remove unused case study doc, fix broken link

### DIFF
--- a/docs/case-study/metabit-trading-study.md
+++ b/docs/case-study/metabit-trading-study.md
@@ -1,7 +1,0 @@
----
-sidebar_label: Metabit Trading's Case Study
-sidebar_position: 3
----
-
-# Metabit Trading's Case Study
-to be updated.

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -149,7 +149,7 @@ The output should be like:
 For more use cases about Fluid, please refer to our tutorials:
 - [Speed Up Accessing Remote Files](/docs/tutorials/dataset-creation/accelerate-data-accessing-posix)
 - [Cache Co-locality for Workload Scheduling](/docs/tutorials/dataset-creation/cache-co-locality)
-- [Accelerate Machine Learning Training with Fluid](/docs/tutorials/Advanced/machine-learning-workload)
+- [Accelerate Machine Learning Training with Fluid](/docs/tutorials/advanced/machine-learning-workload)
 
 ### Uninstall Fluid
 


### PR DESCRIPTION
1. Remove unused case study document.
2. Fix broken link.